### PR TITLE
Add option for terms to be created 

### DIFF
--- a/wagtailterms/default_settings.py
+++ b/wagtailterms/default_settings.py
@@ -6,9 +6,15 @@ from django.conf import settings
 DEFAULT_WAGTAILTERMS_SETTINGS = {
     'icon': 'snippet',
     'menu_order': 200,
-    'style': "text-decoration-line: underline; text-decoration-color: green;text-decoration-thickness: "
+    'style': "text-decoration-line: underline; text-decoration-color: green; text-decoration-thickness: "
              "3px;color:green;",
-    'disable_tags': False
+    'class': "term",
+    'disable_tags': False,
+    'embedded_tooltip': False, # Make tooltip from data-[...] attribute
+    'add_link': False, # Add link to tooltip
+    'base_url': "", # URL for link
+    'as_anchor': True, # if link is # on base_url or /
+    'max_word_length': 40
 }
 
 

--- a/wagtailterms/templates/wagtailterms/embedded_wagtailterms.html
+++ b/wagtailterms/templates/wagtailterms/embedded_wagtailterms.html
@@ -1,0 +1,8 @@
+<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://unpkg.com/tippy.js@6"></script>
+<script>
+    tippy("[data-tippy-content]", {
+        allowHTML: true,
+        interactive: true
+    });
+</script>

--- a/wagtailterms/wagtail_hooks.py
+++ b/wagtailterms/wagtail_hooks.py
@@ -7,13 +7,14 @@ from wagtail.admin.rich_text.converters.html_to_contentstate import (
     InlineEntityElementHandler,
 )
 from django.utils.safestring import mark_safe
+from django.utils.text import Truncator
+from django.template.defaultfilters import slugify
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet
 from .default_settings import get_setting
 from .models import Term
 
 TERM_ICON = get_setting('icon')
-
 
 @hooks.register("insert_editor_js")
 def editor_js():
@@ -70,17 +71,38 @@ def term_entity_decorator(props):
     Draft.js ContentState to database HTML.
     Converts the TERM entities into a span tag.
     """
+
+    attrs = {
+        "style": get_setting("style"),
+        "data-term": props["term"]["id"]
+    }
+
+    class_setting = get_setting("class")
+    if class_setting:
+        attrs["class"] = class_setting
+
+    if get_setting("embedded_tooltip"):
+        base_url = get_setting("base_url")
+        if get_setting("as_anchor"):
+            a_block = f"""
+                <a href={base_url+"#"+slugify(props["term"]["term"])} target="_blank">More</a>
+            """
+        else:
+            a_block = f"""
+                <a href={base_url+"/"+slugify(props["term"]["term"])} target="_blank">More</a>
+            """
+
+        max_word_length = get_setting("max_word_length")
+        definition = Truncator(props["term"]["definition"]).words(max_word_length, html=True)
+
+        attrs["data-tippy-content"] = f"""
+            <h4>{props["term"]["term"]}</h4>
+            {definition}
+            {a_block}
+        """
+
     return DOM.create_element(
-        "span",
-        {
-            "style": get_setting("style"),
-            "class": get_setting("class"),
-            "data-term": props["term"]["id"],
-            "data-tippy-content": f"""
-                <h4>{props["term"]["term"]}</h4>
-                <p>{props["term"]["definition"]}</p>
-            """,
-        },
+        "span", attrs,
         props["children"],
     )
 
@@ -128,7 +150,7 @@ class TermViewSet(SnippetViewSet):
         if not get_setting('disable_tags'):
             panel_items.append(FieldPanel("tags"))
         return panel_items
-    
+
     icon = TERM_ICON
     add_to_admin_menu = True
     menu_label = "Terms"

--- a/wagtailterms/wagtail_hooks.py
+++ b/wagtailterms/wagtail_hooks.py
@@ -73,8 +73,13 @@ def term_entity_decorator(props):
     return DOM.create_element(
         "span",
         {
-            "style": get_setting('style'),
+            "style": get_setting("style"),
+            "class": get_setting("class"),
             "data-term": props["term"]["id"],
+            "data-tippy-content": f"""
+                <h4>{props["term"]["term"]}</h4>
+                <p>{props["term"]["definition"]}</p>
+            """,
         },
         props["children"],
     )


### PR DESCRIPTION
Hi @smark-1 
Thank you for this plugin!

I wanted to submit a PR for an alternative way to populate the terms via `data-[...]` attributes instead of requests via DRF. The idea is that we can pass `term` and `definition` to the tooltip directly.

In addition, this adds a couple of additional settings to be able to limit the word length of the tooltip, and to add a link on the bottom part that brings you to a different page (customizable) with a list of terms. An example of this can be found here:

https://github.com/more4nature-eu/knowledge-platform/pull/64

There are a couple of pending things that I can work on if you like the idea.